### PR TITLE
ci: install Catch2 dev package for coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,8 +22,8 @@ jobs:
           sudo apt-get update
           # Core build tools + lcov
           sudo apt-get install -y cmake ninja-build lcov
-          # Optional: Catch2 (package name differs by distro; keep best-effort)
-          sudo apt-get install -y catch2 || true
+          # Catch2 headers/library (package name differs by distro)
+          sudo apt-get install -y catch2 libcatch2-dev || true
 
       - name: Configure (Coverage)
         run: |


### PR DESCRIPTION
## Summary
- fix coverage workflow by installing Catch2 development headers

## Testing
- `yamllint .github/workflows/coverage.yml` *(fails: command not found)*
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bf7a2c66f083309afc598514024d3b