### PR TITLE
Fetch Catch2 for coverage tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,19 @@ if(NOT Catch2_FOUND)
     endif()
 endif()
 
+# As a final fallback, fetch Catch2 using FetchContent
+if(NOT Catch2_FOUND)
+    include(FetchContent)
+    message(STATUS "Catch2 not found locally. Fetching from upstream...")
+    FetchContent_Declare(
+        Catch2
+        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_TAG v3.4.0
+    )
+    FetchContent_MakeAvailable(Catch2)
+    set(Catch2_FOUND TRUE)
+endif()
+
 # Configure Test Executable
 file(GLOB_RECURSE TEST_SOURCES "tests/*.cpp" "tests/*.cc" "tests/*.cxx")
 if(Catch2_FOUND AND TEST_SOURCES)


### PR DESCRIPTION
## Summary
- ensure Catch2 is available by fetching it via CMake's FetchContent if not found locally

## Testing
- `cmake -S . -B build-cov -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-O0 -g --coverage" -DCMAKE_CXX_FLAGS="-O0 -g --coverage" -DCMAKE_EXE_LINKER_FLAGS="--coverage" -DCMAKE_SHARED_LINKER_FLAGS="--coverage"` *(fails: CONNECT tunnel failed while cloning Catch2)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7a2c66f083309afc598514024d3b