### PR TITLE
Ignore lcov mismatch errors

### DIFF
--- a/.lcovrc
+++ b/.lcovrc
@@ -1,0 +1,2 @@
+# Configuration for lcov to ignore mismatched end line errors
+geninfo_ignore_errors = mismatch


### PR DESCRIPTION
## Summary
- configure lcov to ignore mismatched end line errors to prevent coverage runs from failing

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`
- ⚠️ `lcov --directory build-cov --capture --output-file coverage.info` *(lcov not installed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c038105aa08330b2a4d1775e872280