### PR TITLE
ci: install latest lcov from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,15 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build ccache lcov
+          sudo apt-get install -y cmake ninja-build ccache
+
+      - name: Install lcov
+        run: |
+          curl -L https://github.com/linux-test-project/lcov/releases/latest/download/lcov.tar.gz -o lcov.tar.gz
+          tar -xzf lcov.tar.gz
+          cd lcov-*
+          make install PREFIX=$HOME/.local
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Configure (Debug)
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,10 +20,18 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update
-          # Core build tools + lcov
-          sudo apt-get install -y cmake ninja-build lcov
+          # Core build tools
+          sudo apt-get install -y cmake ninja-build
           # Catch2 headers/library (package name differs by distro)
           sudo apt-get install -y catch2 libcatch2-dev || true
+
+      - name: Install lcov
+        run: |
+          curl -L https://github.com/linux-test-project/lcov/releases/latest/download/lcov.tar.gz -o lcov.tar.gz
+          tar -xzf lcov.tar.gz
+          cd lcov-*
+          make install PREFIX=$HOME/.local
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Configure (Coverage)
         run: |


### PR DESCRIPTION
## Summary
- build lcov from latest release instead of apt
- add installed lcov to PATH for coverage runs

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c03e15451c8330a2a8b83f4a8bc2e8