### PR TITLE
ci: install latest lcov from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,18 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build ccache lcov
+          sudo apt-get install -y cmake ninja-build ccache make libcapture-tiny-perl
+
+      - name: Install lcov
+        run: |
+          LCOV_TAG=$(curl -s https://api.github.com/repos/linux-test-project/lcov/releases/latest | grep tag_name | cut -d '"' -f 4)
+          LCOV_VERSION=${LCOV_TAG#v}
+          curl -L "https://github.com/linux-test-project/lcov/releases/download/${LCOV_TAG}/lcov-${LCOV_VERSION}.tar.gz" -o lcov.tar.gz
+          tar -xzf lcov.tar.gz
+          cd "lcov-${LCOV_VERSION}"
+          make install PREFIX=$HOME/.local
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          $HOME/.local/bin/lcov --version
 
       - name: Configure (Debug)
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,10 +20,21 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update
-          # Core build tools + lcov
-          sudo apt-get install -y cmake ninja-build lcov
+          # Core build tools
+          sudo apt-get install -y cmake ninja-build make libcapture-tiny-perl
           # Catch2 headers/library (package name differs by distro)
           sudo apt-get install -y catch2 libcatch2-dev || true
+
+      - name: Install lcov
+        run: |
+          LCOV_TAG=$(curl -s https://api.github.com/repos/linux-test-project/lcov/releases/latest | grep tag_name | cut -d '"' -f 4)
+          LCOV_VERSION=${LCOV_TAG#v}
+          curl -L "https://github.com/linux-test-project/lcov/releases/download/${LCOV_TAG}/lcov-${LCOV_VERSION}.tar.gz" -o lcov.tar.gz
+          tar -xzf lcov.tar.gz
+          cd "lcov-${LCOV_VERSION}"
+          make install PREFIX=$HOME/.local
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          $HOME/.local/bin/lcov --version
 
       - name: Configure (Coverage)
         run: |


### PR DESCRIPTION
## Summary
- build lcov from latest release instead of apt
- add installed lcov to PATH for coverage runs
- fetch release tag via GitHub API to reliably download tarball
- install Capture::Tiny Perl module and verify lcov installation to prevent coverage failures

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `sudo apt-get update` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c03e15451c8330a2a8b83f4a8bc2e8